### PR TITLE
fix: dataframe is not filtered data for error Input file has zero column

### DIFF
--- a/CytoSig/CytoSig_run.py
+++ b/CytoSig/CytoSig_run.py
@@ -129,7 +129,7 @@ def main():
                 sys.exit(1)
 
             # filter bad genes
-            response = response.loc[(response == 0).mean(axis=1) < zero_ratio]
+            response = response.loc[(response == 0).sum(axis=1)/response.shape[1] < zero_ratio]
             
             # filter bad cell barcodes
             response = response.loc[:, response.sum() >= min_count]

--- a/CytoSig/Util.py
+++ b/CytoSig/Util.py
@@ -141,7 +141,7 @@ def load_cell_ranger(genes, features, barcodes, matrix, min_count, included = No
         matrix = matrix.loc[matrix.index.intersection(included)]
     
     # remove empty genes
-    matrix = matrix.loc[(matrix == 0).mean(axis=1) < 1]
+    matrix = matrix.loc[(matrix == 0).sum(axis=1)/matrix.shape[1] < 1]
     
     return matrix
 


### PR DESCRIPTION
I try to run example 2 with cellranger output files with your code but facing `Input file %s has zero column.` error. I notice that the response in `CytoSig_run.py` file will have shape (0, n_cols). So I think the issue belongs to filter genes with `dataframe.loc`. Put `.index` can fix this problem.

I use python version 3.10.9 and pandas version is 2.1.3.